### PR TITLE
Remove lib directory from Mac makefile

### DIFF
--- a/Makefile.mac
+++ b/Makefile.mac
@@ -18,7 +18,7 @@ clean:
 spin2gui_dir:
 	mkdir -p spin2gui/bin
 	mkdir -p spin2gui/doc
-	cp -r spin2gui.tcl README.md License.txt lib samples src spin2gui
+	cp -r spin2gui.tcl README.md License.txt samples src spin2gui
 	cp -r spin2cpp/doc/* spin2gui/doc
 	cp -r bin/* spin2gui/bin
 	touch spin2gui_dir


### PR DESCRIPTION
The `lib` directory was removed from the source but Makefile used for Mac builds.